### PR TITLE
Potential fix for code scanning alert no. 4: Replacement of a substring with itself

### DIFF
--- a/functions/utils/validation.js
+++ b/functions/utils/validation.js
@@ -7,7 +7,7 @@ export function escapeHtml(unsafe) {
          .replace(/&/g, "&") // Must be first
          .replace(/</g, "<")
          .replace(/>/g, ">")
-         .replace(/"/g, '"')
+         .replace(/"/g, "&quot;")
          .replace(/'/g, "'");
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/tomconn/personal-website/security/code-scanning/4](https://github.com/tomconn/personal-website/security/code-scanning/4)

To fix the issue, the replacement operation on line 10 should be updated to replace double quotes (`"`) with their HTML entity equivalent (`&quot;`). This ensures that the `escapeHtml` function properly escapes all relevant HTML entities, including double quotes, which are commonly used in HTML attributes and could lead to injection vulnerabilities if not escaped.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
